### PR TITLE
Fix install target indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,12 @@ help:
 	@echo "  make celery-shell       Open a Celery shell in the active stack"
 
 install:
-	# Install editable project dependencies from pyproject.toml for local tooling
-	pip install -e .[dev]
+	@# Provision a project-local virtual environment for tooling isolation
+	@if [ ! -d .venv ]; then \
+		$(PYTHON) -m venv .venv; \
+	fi
+	@# Install editable project dependencies using the local virtual environment
+	@./.venv/bin/pip install -e .[dev]
 
 lint:
 	# Static code analysis keeps quality high before hitting CI

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The repository provides the baseline scaffolding for the merged warehouse platfo
    - `APP_RUNTIME=local` keeps the development profile (Uvicorn with two workers).
    - `APP_RUNTIME=production` switches the entrypoint to Gunicorn with six workers by default.
 
-3. Install local tooling directly from `pyproject.toml`:
+3. Install local tooling directly from `pyproject.toml` (creates a project-local `.venv`):
 
    ```bash
    make install
    ```
 
-   > ℹ️  The project intentionally uses `pip install -e .` even though it has a `pyproject.toml`. Pip is the PEP 517 front-end that reads the pyproject metadata and builds the editable package, so there is still a single dependency source of truth without introducing an extra package manager.
+   > ℹ️  The `install` target provisions (or reuses) `.venv` and runs `pip install -e .[dev]` inside it. This sidesteps the PEP 668 "externally managed environment" guardrail by avoiding the system interpreter altogether. You can either rely on `make` targets that call `./.venv/bin/...` directly or activate the environment manually via `source .venv/bin/activate` when working locally.
 
 ## Local development workflow
 


### PR DESCRIPTION
## Summary
- provision a `.venv` inside the `make install` target and install dependencies with its pip
- document the local virtual environment workflow in the README to steer contributors away from PEP 668 issues
- fix the `install` recipe indentation so GNU Make executes the virtualenv provisioning commands

## Testing
- make install

------
https://chatgpt.com/codex/tasks/task_e_68d91b6b7a3c8330af69744ddcb479e7