### PR TITLE
Gracefully handle missing Telegram configuration

### DIFF
--- a/src/warehouse_service/notifications/telegram.py
+++ b/src/warehouse_service/notifications/telegram.py
@@ -13,17 +13,40 @@ class TelegramNotifier:
 
     def __init__(self, bot_token: str | None = None) -> None:
         settings = get_settings()
-        self.bot_token = bot_token or settings.telegram.bot_token
-        self.base_url = f"https://api.telegram.org/bot{self.bot_token}"
-        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=10)
+        configured_token = bot_token or settings.telegram.bot_token
+        self.bot_token = configured_token
         self.critical_chat_id = settings.telegram.critical_chat_id
         self.health_chat_id = settings.telegram.health_chat_id
 
+        token_missing = not configured_token or configured_token == "replace-me"
+        if token_missing:
+            self._client: httpx.AsyncClient | None = None
+            self._enabled = False
+            logger.info("Telegram notifications disabled: bot token is not configured")
+        else:
+            base_url = f"https://api.telegram.org/bot{configured_token}"
+            self._client = httpx.AsyncClient(base_url=base_url, timeout=10)
+            self._enabled = True
+
     async def send_message(self, chat_id: int, text: str, *, parse_mode: str | None = "MarkdownV2") -> None:
+        if not self._enabled:
+            logger.debug("Skipping Telegram notification because notifier is disabled")
+            return
+        if chat_id <= 0:
+            logger.warning("Skipping Telegram notification because chat id is not configured")
+            return
+        if self._client is None:  # Safety net for type checkers
+            logger.debug("Telegram HTTP client is not available, skipping notification")
+            return
+
         payload = {"chat_id": chat_id, "text": text, "parse_mode": parse_mode}
         response = await self._client.post("/sendMessage", json=payload)
         if response.is_error:
-            logger.error("Failed to send Telegram message", status_code=response.status_code, body=response.text)
+            logger.error(
+                "Failed to send Telegram message",
+                status_code=response.status_code,
+                body=response.text,
+            )
             response.raise_for_status()
 
     async def notify_startup(self, ok: bool, details: str) -> None:
@@ -37,7 +60,8 @@ class TelegramNotifier:
         await self.send_message(chat_id, f"{status} *Warehouse daily health report*\n{details}")
 
     async def aclose(self) -> None:
-        await self._client.aclose()
+        if self._client is not None:
+            await self._client.aclose()
 
 
 __all__ = ["TelegramNotifier"]

--- a/src/warehouse_service/system_checks/startup.py
+++ b/src/warehouse_service/system_checks/startup.py
@@ -20,7 +20,10 @@ async def main(notify: bool) -> int:
     if notify:
         notifier = TelegramNotifier()
         try:
-            await notifier.notify_startup(ok, summary)
+            try:
+                await notifier.notify_startup(ok, summary)
+            except Exception:
+                logger.exception("Failed to send startup notification")
         finally:
             await notifier.aclose()
     if ok:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from warehouse_service.config import get_settings
+from warehouse_service.notifications.telegram import TelegramNotifier
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def configure_base_env(monkeypatch, *, token: str, critical_id: str, health_id: str) -> None:
+    monkeypatch.setenv("APP_NAME", "Test App")
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://user:pass@localhost:5432/db")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("CELERY_BROKER_URL", "redis://localhost:6379/1")
+    monkeypatch.setenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/2")
+    monkeypatch.setenv("CELERY_DB_SCHEDULER_URL", "postgresql+psycopg://user:pass@localhost:5432/db")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", token)
+    monkeypatch.setenv("TELEGRAM_CRITICAL_CHAT_ID", critical_id)
+    monkeypatch.setenv("TELEGRAM_HEALTH_CHAT_ID", health_id)
+    monkeypatch.setenv("SUPERADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("SUPERADMIN_PASSWORD", "secret")
+
+
+@pytest.mark.anyio(backend="asyncio")
+async def test_notifier_disabled_when_token_missing(monkeypatch):
+    configure_base_env(monkeypatch, token="replace-me", critical_id="0", health_id="0")
+
+    notifier = TelegramNotifier()
+
+    assert notifier._enabled is False  # type: ignore[attr-defined]
+
+    await notifier.notify_startup(ok=True, details="All good")
+    await notifier.aclose()
+
+
+@pytest.mark.anyio(backend="asyncio")
+async def test_notifier_skips_when_chat_not_configured(monkeypatch):
+    configure_base_env(monkeypatch, token="valid-token", critical_id="0", health_id="0")
+
+    notifier = TelegramNotifier()
+
+    calls: list[None] = []
+
+    async def fail_post(*args, **kwargs):  # pragma: no cover - guarded by chat id check
+        calls.append(None)
+        raise AssertionError("HTTP client should not be called when chat id is missing")
+
+    if notifier._client is not None:
+        notifier._client.post = fail_post  # type: ignore[assignment]
+
+    await notifier.notify_startup(ok=False, details="Failed checks")
+    await notifier.aclose()
+
+    assert not calls


### PR DESCRIPTION
## Summary
- disable Telegram notifications when credentials are not configured and guard against missing chat IDs
- prevent startup checks from crashing when Telegram delivery fails
- add regression tests covering the new notification safeguards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9221cf8c883308eb12221ed03022d