### PR TITLE
Use SQLAlchemy-backed Celery beat scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ COPY ./scripts ./scripts
 # Expose src to Python for interactive shells and celery workers
 ENV PYTHONPATH=/app/src
 
-# Ensure the entrypoint is executable inside slim base images
-RUN chmod +x /app/scripts/entrypoint.sh
+# Ensure helper scripts are executable inside slim base images
+RUN chmod +x /app/scripts/*.sh
 
 # Delegate process supervision to the Bash entrypoint (runtime mode decided there)
 CMD ["/app/scripts/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -136,10 +136,19 @@ prod-shell:
 	$(compose_prod) exec app bash
 
 celery-shell:
-	# Connect to the Celery shell using STACK=local (default) or STACK=prod
-	@stack=${STACK:-local}; \
-	if [ "$$stack" = "prod" ]; then \
-	$(compose_prod) exec worker celery shell -A warehouse_service.tasks.celery_app:celery; \
-	else \
-	$(compose_local) exec worker celery shell -A warehouse_service.tasks.celery_app:celery; \
-	fi
+        # Connect to the Celery shell using STACK=local (default) or STACK=prod
+        @stack=${STACK:-local}; \
+        if [ "$$stack" = "prod" ]; then \
+        $(compose_prod) exec worker celery shell -A warehouse_service.tasks.celery_app:celery; \
+        else \
+        $(compose_local) exec worker celery shell -A warehouse_service.tasks.celery_app:celery; \
+        fi
+
+celery-sync:
+        # Persist configured periodic tasks to the SQLAlchemy beat backend
+        @stack=${STACK:-local}; \
+        if [ "$$stack" = "prod" ]; then \
+        $(compose_prod) run --rm beat python -m warehouse_service.tasks.scheduler_sync; \
+        else \
+        $(compose_local) run --rm beat python -m warehouse_service.tasks.scheduler_sync; \
+        fi

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Additional helpers:
 
 - `make local-shell` – open a shell in the app container.
 - `make celery-shell` – open a Celery shell (override with `STACK=prod` for the production stack).
+- `make celery-sync` – sync configured periodic tasks into the SQLAlchemy-backed Celery beat tables.
 - `make check` – run Ruff linting followed by pytest.
 
 ## Production-oriented commands
@@ -71,7 +72,7 @@ make prod-down
 
 - **FastAPI** application served by Uvicorn (local) or Gunicorn (production) depending on `APP_RUNTIME`.
 - **SQLModel** with PostgreSQL for RBAC entities, inventory, and auditing layers.
-- **Celery** worker and beat leveraging the PostgreSQL-backed `celery_sqlalchemy_scheduler` for the daily 09:00 (Europe/Minsk) health report.
+- **Celery** worker and beat leveraging the PostgreSQL-backed `sqlalchemy-celery-beat` scheduler for the daily 09:00 (Europe/Minsk) health report.
 - **Redis** for background job brokering and cache-like features.
 - **Telegram** notifications for startup diagnostics and scheduled health summaries.
 

--- a/alembic/versions/0002_create_celery_scheduler_tables.py
+++ b/alembic/versions/0002_create_celery_scheduler_tables.py
@@ -1,0 +1,34 @@
+"""Create tables for SQLAlchemy-backed Celery beat scheduler."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy_celery_beat import models
+
+revision = "0002_create_celery_scheduler_tables"
+down_revision = "0001_create_core_tables"
+branch_labels = None
+depends_on = None
+
+CELERY_SCHEMA = "celery_schema"
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {CELERY_SCHEMA}"))
+
+    schema_connection = connection.execution_options(
+        schema_translate_map={"celery_schema": CELERY_SCHEMA}
+    )
+    models.ModelBase.metadata.create_all(schema_connection, checkfirst=True)
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    schema_connection = connection.execution_options(
+        schema_translate_map={"celery_schema": CELERY_SCHEMA}
+    )
+    models.ModelBase.metadata.drop_all(schema_connection, checkfirst=True)
+
+    connection.execute(sa.text(f"DROP SCHEMA IF EXISTS {CELERY_SCHEMA} CASCADE"))

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -91,17 +91,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command:
-      [
-        "celery",
-        "-A",
-        "warehouse_service.tasks.celery_app:celery",
-        "beat",
-        "-l",
-        "info",
-        "-S",
-        "celery_sqlalchemy_scheduler.schedulers:DatabaseScheduler"
-      ]
+    command: ["/app/scripts/celery-beat-entrypoint.sh"]
     env_file:
       - .env
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -91,17 +91,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command:
-      [
-        "celery",
-        "-A",
-        "warehouse_service.tasks.celery_app:celery",
-        "beat",
-        "-l",
-        "info",
-        "-S",
-        "celery_sqlalchemy_scheduler.schedulers:DatabaseScheduler"
-      ]
+    command: ["/app/scripts/celery-beat-entrypoint.sh"]
     env_file:
       - .env
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "alembic>=1.12",
     "celery[redis,sqlalchemy]>=5.3",
-    "celery-sqlalchemy-scheduler>=0.3,<0.4",
+    "sqlalchemy-celery-beat>=0.8.4,<0.9",
     "fastapi>=0.110",
     "httpx>=0.27",
     "loguru>=0.7",

--- a/scripts/celery-beat-entrypoint.sh
+++ b/scripts/celery-beat-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+export PYTHONPATH="/app/src:${PYTHONPATH:-}"
+
+python -m warehouse_service.tasks.scheduler_sync
+
+exec celery -A warehouse_service.tasks.celery_app:celery \
+  beat -l info -S sqlalchemy_celery_beat.schedulers:DatabaseScheduler

--- a/src/warehouse_service/tasks/celery_app.py
+++ b/src/warehouse_service/tasks/celery_app.py
@@ -9,6 +9,8 @@ from celery.schedules import crontab
 
 from warehouse_service.config import get_settings
 
+BEAT_SCHEMA = "celery_schema"
+
 settings = get_settings()
 
 celery = Celery(
@@ -20,8 +22,10 @@ celery = Celery(
 celery.conf.update(
     timezone=settings.timezone,
     enable_utc=False,
-    beat_scheduler="celery_sqlalchemy_scheduler.schedulers:DatabaseScheduler",
+    beat_scheduler="sqlalchemy_celery_beat.schedulers:DatabaseScheduler",
     beat_dburi=settings.redis.scheduler_url,
+    beat_schema=BEAT_SCHEMA,
+    beat_engine_options={"pool_pre_ping": True},
     beat_schedule={
         "daily-health-check": {
             "task": "warehouse_service.tasks.health.daily_health_check",

--- a/src/warehouse_service/tasks/scheduler_sync.py
+++ b/src/warehouse_service/tasks/scheduler_sync.py
@@ -1,0 +1,44 @@
+"""Helpers to bootstrap the SQLAlchemy-backed Celery beat schedule."""
+
+from __future__ import annotations
+
+import logging
+
+from celery.app.base import Celery
+from sqlalchemy_celery_beat.schedulers import DatabaseScheduler
+
+from warehouse_service.tasks.celery_app import BEAT_SCHEMA, celery
+
+logger = logging.getLogger(__name__)
+
+
+def sync_schedule(app: Celery | None = None) -> None:
+    """Ensure configured periodic tasks are persisted in the scheduler backend."""
+
+    app = app or celery
+
+    logger.info(
+        "Syncing Celery beat schedule to SQLAlchemy backend",
+        extra={"scheduler_schema": BEAT_SCHEMA},
+    )
+
+    scheduler = DatabaseScheduler(app=app, lazy=True)
+    try:
+        scheduler.setup_schedule()
+        scheduler.sync()
+    finally:
+        scheduler.close()
+
+    logger.info("Celery beat schedule successfully synchronised")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint used by container helpers and operational scripts."""
+
+    logging.basicConfig(level=logging.INFO)
+    sync_schedule()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module CLI guard
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the legacy celery-sqlalchemy scheduler dependency with sqlalchemy-celery-beat and enable the new DatabaseScheduler in the Celery app
- add a CLI helper and container entrypoint to sync periodic tasks into the Postgres-backed beat tables and expose it via docker-compose/Makefile helpers
- create an Alembic migration that provisions the celery_schema schema and scheduler tables used by sqlalchemy-celery-beat

## Testing
- pytest *(fails: NameError: configure_core_env is not defined in tests/test_notifications.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d92f07ff288330b31f0900965636c0