### PR TITLE
Fix Telegram notifier configuration for missing settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "celery[redis,sqlalchemy]>=5.3",
     "celery-sqlalchemy-scheduler>=0.3,<0.4",
     "fastapi>=0.110",
+    "jinja2>=3.1",
     "httpx>=0.27",
     "loguru>=0.7",
     "psycopg[binary,pool]>=3.1",

--- a/src/warehouse_service/app.py
+++ b/src/warehouse_service/app.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from warehouse_service import __version__
 from warehouse_service.config import get_settings
 from warehouse_service.logging import configure_logging
-from warehouse_service.routes import api_router
+from warehouse_service.routes import admin_router, api_router
 
 
 def create_app() -> FastAPI:
@@ -22,6 +22,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(api_router)
+    app.include_router(admin_router)
 
     @app.get("/health", tags=["monitoring"], summary="Return service health status")
     async def healthcheck() -> dict[str, str]:

--- a/src/warehouse_service/notifications/telegram.py
+++ b/src/warehouse_service/notifications/telegram.py
@@ -30,8 +30,8 @@ class TelegramNotifier:
                 "Telegram notifications disabled: configuration is incomplete"
             )
             self.bot_token = ""
-            self.critical_chat_id = None
-            self.health_chat_id = None
+            self.critical_chat_id = 0
+            self.health_chat_id = 0
             self._client = None
             self._enabled = False
             return
@@ -54,7 +54,7 @@ class TelegramNotifier:
         if not self._enabled:
             logger.debug("Skipping Telegram notification because notifier is disabled")
             return
-        if chat_id is None:
+        if not chat_id:
             logger.warning("Skipping Telegram notification because chat id is not configured")
             return
         if self._client is None:  # Safety net for type checkers

--- a/src/warehouse_service/routes/__init__.py
+++ b/src/warehouse_service/routes/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from .admin import admin_router
+
 api_router = APIRouter(prefix="/api")
 
 
@@ -12,4 +14,4 @@ async def status() -> dict[str, str]:
     return {"status": "ok"}
 
 
-__all__ = ["api_router"]
+__all__ = ["api_router", "admin_router"]

--- a/src/warehouse_service/routes/admin.py
+++ b/src/warehouse_service/routes/admin.py
@@ -1,0 +1,164 @@
+"""Administrative views for RBAC management."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlmodel import Session, select
+
+from warehouse_service.db.engine import session_scope
+from warehouse_service.models import Permission, Role
+
+TEMPLATES = Jinja2Templates(
+    directory=str(Path(__file__).resolve().parent.parent / "templates")
+)
+
+admin_router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+def get_session() -> Generator[Session, None, None]:
+    with session_scope() as session:
+        yield session
+
+
+@admin_router.get("/roles", response_class=HTMLResponse, summary="Список ролей")
+def list_roles(
+    request: Request,
+    session: Session = Depends(get_session),
+) -> HTMLResponse:
+    roles = session.exec(select(Role).order_by(Role.name)).all()
+    role_rows = []
+    for role in roles:
+        permissions = list(role.permissions or [])
+        users = list(role.users or [])
+        role_rows.append(
+            {
+                "id": role.id,
+                "name": role.name,
+                "description": role.description,
+                "permission_count": len(permissions),
+                "user_count": len(users),
+                "updated_at": role.updated_at.isoformat() if role.updated_at else None,
+            }
+        )
+
+    return TEMPLATES.TemplateResponse(
+        "admin/roles/list.html",
+        {
+            "request": request,
+            "title": "Роли",
+            "roles": role_rows,
+        },
+    )
+
+
+@admin_router.get(
+    "/roles/{role_id}",
+    response_class=HTMLResponse,
+    summary="Детали роли",
+)
+def role_detail(
+    role_id: int,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> HTMLResponse:
+    role = session.get(Role, role_id)
+    if role is None:
+        raise HTTPException(status_code=404, detail="Роль не найдена")
+
+    permissions = [
+        {
+            "id": assignment.permission.id if assignment.permission else None,
+            "scope": assignment.permission.scope if assignment.permission else "—",
+            "action": assignment.permission.action if assignment.permission else "—",
+            "description": assignment.permission.description if assignment.permission else None,
+            "assigned_at": assignment.created_at.isoformat()
+            if assignment.created_at
+            else None,
+        }
+        for assignment in sorted(
+            list(role.permissions or []),
+            key=lambda item: (
+                item.permission.scope if item.permission else "",
+                item.permission.action if item.permission else "",
+            ),
+        )
+    ]
+
+    members = [
+        {
+            "id": membership.user.id if membership.user else None,
+            "email": membership.user.email if membership.user else "—",
+            "assigned_at": membership.created_at.isoformat()
+            if membership.created_at
+            else None,
+        }
+        for membership in sorted(
+            list(role.users or []),
+            key=lambda item: (item.user.email if item.user else ""),
+        )
+    ]
+
+    role_payload = {
+        "id": role.id,
+        "name": role.name,
+        "description": role.description,
+        "created_at": role.created_at.isoformat() if role.created_at else None,
+        "updated_at": role.updated_at.isoformat() if role.updated_at else None,
+    }
+
+    return TEMPLATES.TemplateResponse(
+        "admin/roles/detail.html",
+        {
+            "request": request,
+            "title": f"Роль · {role.name}",
+            "role": role_payload,
+            "permissions": permissions,
+            "members": members,
+        },
+    )
+
+
+@admin_router.get(
+    "/permissions",
+    response_class=HTMLResponse,
+    summary="Список разрешений",
+)
+def list_permissions(
+    request: Request,
+    session: Session = Depends(get_session),
+) -> HTMLResponse:
+    permissions = session.exec(
+        select(Permission).order_by(Permission.scope, Permission.action)
+    ).all()
+    permission_rows = []
+    for permission in permissions:
+        roles = list(permission.roles or [])
+        permission_rows.append(
+            {
+                "id": permission.id,
+                "scope": permission.scope,
+                "action": permission.action,
+                "description": permission.description,
+                "role_count": len(roles),
+                "updated_at": permission.updated_at.isoformat()
+                if permission.updated_at
+                else None,
+            }
+        )
+
+    return TEMPLATES.TemplateResponse(
+        "admin/permissions/list.html",
+        {
+            "request": request,
+            "title": "Разрешения",
+            "permissions": permission_rows,
+        },
+    )
+
+
+__all__ = ["admin_router"]

--- a/src/warehouse_service/templates/admin/permissions/list.html
+++ b/src/warehouse_service/templates/admin/permissions/list.html
@@ -1,0 +1,35 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+  <div class="page-header">
+    <h2>Разрешения</h2>
+    <p>Полный перечень разрешений и количество ролей, в которых они используются.</p>
+  </div>
+  {% if permissions %}
+    <div class="card">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Scope</th>
+            <th>Action</th>
+            <th>Описание</th>
+            <th>Ролей</th>
+            <th>Изменено</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for permission in permissions %}
+            <tr>
+              <td>{{ permission.scope }}</td>
+              <td>{{ permission.action }}</td>
+              <td>{{ permission.description or "—" }}</td>
+              <td><span class="badge">{{ permission.role_count }}</span></td>
+              <td>{{ permission.updated_at or "—" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <div class="empty-state">Разрешения ещё не заведены.</div>
+  {% endif %}
+{% endblock %}

--- a/src/warehouse_service/templates/admin/roles/detail.html
+++ b/src/warehouse_service/templates/admin/roles/detail.html
@@ -1,0 +1,61 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+  <div class="page-header">
+    <h2>{{ role.name }}</h2>
+    <p>{{ role.description or "Роль без описания" }}</p>
+  </div>
+  <div class="grid-two-column">
+    <div class="card">
+      <h3>Сводка</h3>
+      <ul class="meta-list">
+        <li><span>Идентификатор</span><strong>#{{ role.id }}</strong></li>
+        <li><span>Пользователей</span><strong>{{ members|length }}</strong></li>
+        <li><span>Разрешений</span><strong>{{ permissions|length }}</strong></li>
+        <li><span>Создано</span><strong>{{ role.created_at or "—" }}</strong></li>
+        <li><span>Обновлено</span><strong>{{ role.updated_at or "—" }}</strong></li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3>Участники</h3>
+      {% if members %}
+        <ul class="meta-list">
+          {% for member in members %}
+            <li>
+              <span>{{ member.email }}</span>
+              <span>{{ member.assigned_at or "—" }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="empty-state">К роли пока не привязаны пользователи.</div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="card" style="margin-top: 1.5rem;">
+    <h3>Разрешения роли</h3>
+    {% if permissions %}
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Scope</th>
+            <th>Action</th>
+            <th>Описание</th>
+            <th>Назначено</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for permission in permissions %}
+            <tr>
+              <td>{{ permission.scope }}</td>
+              <td>{{ permission.action }}</td>
+              <td>{{ permission.description or "—" }}</td>
+              <td>{{ permission.assigned_at or "—" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <div class="empty-state">Для роли пока не назначены разрешения.</div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/src/warehouse_service/templates/admin/roles/list.html
+++ b/src/warehouse_service/templates/admin/roles/list.html
@@ -1,0 +1,37 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+  <div class="page-header">
+    <h2>Роли</h2>
+    <p>Справочник ролей с количеством привязанных пользователей и разрешений.</p>
+  </div>
+  {% if roles %}
+    <div class="card">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Название</th>
+            <th>Описание</th>
+            <th>Разрешения</th>
+            <th>Пользователи</th>
+            <th>Изменено</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for role in roles %}
+            <tr>
+              <td>
+                <a href="/admin/roles/{{ role.id }}">{{ role.name }}</a>
+              </td>
+              <td>{{ role.description or "—" }}</td>
+              <td><span class="badge">{{ role.permission_count }}</span></td>
+              <td><span class="badge">{{ role.user_count }}</span></td>
+              <td>{{ role.updated_at or "—" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <div class="empty-state">Роли ещё не настроены.</div>
+  {% endif %}
+{% endblock %}

--- a/src/warehouse_service/templates/layouts/base.html
+++ b/src/warehouse_service/templates/layouts/base.html
@@ -1,11 +1,194 @@
-{# Base layout placeholder - will be extended with real UI components. #}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset="utf-8" />
-    <title>{{ title or "Warehouse" }}</title>
+    <title>{{ title or "Warehouse Admin" }}</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg-color: #f5f6fa;
+        --fg-color: #1f2933;
+        --accent-color: #2563eb;
+        --muted-color: #6b7280;
+        --card-bg: #ffffff;
+        --border-color: #d1d5db;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg-color);
+        color: var(--fg-color);
+      }
+
+      a {
+        color: var(--accent-color);
+        text-decoration: none;
+      }
+
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+
+      .app-shell {
+        display: flex;
+        min-height: 100vh;
+        flex-direction: column;
+      }
+
+      header.app-header {
+        padding: 1.5rem 2rem 1rem;
+        background: var(--card-bg);
+        border-bottom: 1px solid var(--border-color);
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+      }
+
+      header.app-header h1 {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+
+      nav.app-nav {
+        display: flex;
+        gap: 1rem;
+        padding: 0.5rem 2rem 1rem;
+        background: var(--card-bg);
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      nav.app-nav a {
+        font-weight: 500;
+        color: var(--muted-color);
+        padding: 0.35rem 0.6rem;
+        border-radius: 0.5rem;
+      }
+
+      nav.app-nav a.active,
+      nav.app-nav a:hover,
+      nav.app-nav a:focus {
+        color: var(--accent-color);
+        background: rgba(37, 99, 235, 0.12);
+      }
+
+      main.app-content {
+        flex: 1;
+        padding: 2rem;
+      }
+
+      .page-header {
+        margin-bottom: 1.5rem;
+      }
+
+      .page-header h2 {
+        margin: 0;
+        font-size: 1.75rem;
+        font-weight: 600;
+      }
+
+      .page-header p {
+        margin: 0.35rem 0 0;
+        color: var(--muted-color);
+      }
+
+      .card {
+        background: var(--card-bg);
+        border-radius: 1rem;
+        border: 1px solid var(--border-color);
+        padding: 1.5rem;
+        box-shadow: 0 10px 15px -10px rgba(15, 23, 42, 0.2);
+      }
+
+      table.data-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        font-size: 0.95rem;
+      }
+
+      table.data-table th,
+      table.data-table td {
+        padding: 0.75rem 0.85rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      table.data-table th {
+        font-size: 0.8rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--muted-color);
+      }
+
+      table.data-table tbody tr:hover {
+        background: rgba(37, 99, 235, 0.06);
+      }
+
+      .empty-state {
+        padding: 2rem;
+        text-align: center;
+        color: var(--muted-color);
+        border: 1px dashed var(--border-color);
+        border-radius: 0.75rem;
+        background: rgba(15, 23, 42, 0.02);
+      }
+
+      .grid-two-column {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .meta-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .meta-list li {
+        padding: 0.4rem 0;
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        font-size: 0.9rem;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.6rem;
+        font-size: 0.8rem;
+        border-radius: 9999px;
+        background: rgba(37, 99, 235, 0.12);
+        color: var(--accent-color);
+        font-weight: 500;
+      }
+
+      footer.app-footer {
+        padding: 1rem 2rem 2rem;
+        color: var(--muted-color);
+        font-size: 0.85rem;
+      }
+    </style>
   </head>
   <body>
-    {% block content %}{% endblock %}
+    <div class="app-shell">
+      <header class="app-header">
+        <h1>Панель администрирования склада</h1>
+      </header>
+      <nav class="app-nav">
+        <a href="/admin/roles" class="{% if request.url.path.startswith('/admin/roles') %}active{% endif %}">Роли</a>
+        <a href="/admin/permissions" class="{% if request.url.path.startswith('/admin/permissions') %}active{% endif %}">Разрешения</a>
+      </nav>
+      <main class="app-content">
+        {% block content %}{% endblock %}
+      </main>
+      <footer class="app-footer">
+        Управление ролями и разрешениями объединённого сервиса.
+      </footer>
+    </div>
   </body>
 </html>

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -19,19 +19,21 @@ def anyio_backend():
 
 
 
-def configure_base_env(monkeypatch, *, token: str, critical_id: str, health_id: str) -> None:
+def configure_core_env(monkeypatch) -> None:
+    """Populate environment variables required by core settings."""
 
     monkeypatch.setenv("APP_NAME", "Test App")
     monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://user:pass@localhost:5432/db")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     monkeypatch.setenv("CELERY_BROKER_URL", "redis://localhost:6379/1")
     monkeypatch.setenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/2")
-
+    monkeypatch.setenv("CELERY_DB_SCHEDULER_URL", "postgresql+psycopg://user:pass@localhost:5432/db")
 
 
 def configure_base_env(monkeypatch, *, token: str, critical_id: str, health_id: str) -> None:
+    """Populate the full environment expected by the notifier tests."""
 
-    monkeypatch.setenv("CELERY_DB_SCHEDULER_URL", "postgresql+psycopg://user:pass@localhost:5432/db")
+    configure_core_env(monkeypatch)
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", token)
     monkeypatch.setenv("TELEGRAM_CRITICAL_CHAT_ID", critical_id)
     monkeypatch.setenv("TELEGRAM_HEALTH_CHAT_ID", health_id)


### PR DESCRIPTION
## Summary
- add an admin router that renders RBAC management pages for roles and permissions
- style the base layout to match the Baselinker_to_wix admin look and provide tables for RBAC data
- fix the Telegram notifier defaults and test helpers so configuration gaps are handled gracefully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d930ab9d8483309dcadda4af88ad66