### PR TITLE
feat: add Allegro backup frontend module

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.6.8",
+        "date-fns": "^3.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3"
@@ -1884,6 +1885,16 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
+    "date-fns": "^3.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import DashboardPage from './pages/DashboardPage';
 import AdminPage from './pages/AdminPage';
+import AllegroPage from './pages/AllegroPage';
 import { AuthService } from './services/auth';
 
 const App = () => {
@@ -35,6 +36,7 @@ const App = () => {
       >
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/admin" element={<AdminPage />} />
+        <Route path="/allegro" element={<AllegroPage />} />
         <Route path="/catalog" element={<div>Каталог (в разработке)</div>} />
         <Route path="/warehouses" element={<div>Склады (в разработке)</div>} />
       </Route>

--- a/frontend/src/api/allegro.ts
+++ b/frontend/src/api/allegro.ts
@@ -1,0 +1,114 @@
+import axios from 'axios';
+import {
+  AllegroAutomationSettings,
+  AllegroHealthStatus,
+  AllegroOrder,
+  AllegroOrderFilters,
+  AllegroSyncLog,
+  AllegroSyncStats,
+  AllegroToken,
+  CreateTokenPayload,
+  SyncLogsFilters,
+  TriggerSyncPayload,
+  UpdateTokenPayload,
+} from '../types/allegro';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
+
+const allegroClient = axios.create({
+  baseURL: `${API_BASE_URL}/api/allegro`,
+  withCredentials: true,
+});
+
+allegroClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export const fetchTokens = async (): Promise<AllegroToken[]> => {
+  const response = await allegroClient.get<AllegroToken[]>('/tokens');
+  return response.data;
+};
+
+export const createToken = async (payload: CreateTokenPayload): Promise<AllegroToken> => {
+  const response = await allegroClient.post<AllegroToken>('/tokens', payload);
+  return response.data;
+};
+
+export const updateToken = async (
+  tokenId: string,
+  payload: UpdateTokenPayload,
+): Promise<AllegroToken> => {
+  const response = await allegroClient.patch<AllegroToken>(`/tokens/${tokenId}`, payload);
+  return response.data;
+};
+
+export const deleteToken = async (tokenId: string): Promise<void> => {
+  await allegroClient.delete(`/tokens/${tokenId}`);
+};
+
+export const refreshToken = async (tokenId: string): Promise<AllegroToken> => {
+  const response = await allegroClient.post<AllegroToken>(`/tokens/${tokenId}/refresh`);
+  return response.data;
+};
+
+export const toggleTokenActive = async (
+  tokenId: string,
+  isActive: boolean,
+): Promise<AllegroToken> => {
+  const response = await allegroClient.post<AllegroToken>(`/tokens/${tokenId}/${isActive ? 'activate' : 'deactivate'}`);
+  return response.data;
+};
+
+export const fetchSyncStats = async (): Promise<AllegroSyncStats> => {
+  const response = await allegroClient.get<AllegroSyncStats>('/stats');
+  return response.data;
+};
+
+export const triggerManualSync = async (payload: TriggerSyncPayload = {}): Promise<{ queued: boolean; job_id?: string }> => {
+  const response = await allegroClient.post<{ queued: boolean; job_id?: string }>('/sync', payload);
+  return response.data;
+};
+
+export const fetchOrders = async (filters: AllegroOrderFilters = {}): Promise<AllegroOrder[]> => {
+  const response = await allegroClient.get<AllegroOrder[]>('/orders', { params: filters });
+  return response.data;
+};
+
+export const fetchOrder = async (orderId: string): Promise<AllegroOrder> => {
+  const response = await allegroClient.get<AllegroOrder>(`/orders/${orderId}`);
+  return response.data;
+};
+
+export const fetchSyncLogs = async (filters: SyncLogsFilters = {}): Promise<AllegroSyncLog[]> => {
+  const params = { ...filters };
+  if (params.status === 'all') {
+    delete params.status;
+  }
+  if (params.event_type === 'all') {
+    delete params.event_type;
+  }
+  const response = await allegroClient.get<AllegroSyncLog[]>('/logs', { params });
+  return response.data;
+};
+
+export const fetchAutomationSettings = async (): Promise<AllegroAutomationSettings> => {
+  const response = await allegroClient.get<AllegroAutomationSettings>('/automation-settings');
+  return response.data;
+};
+
+export const updateAutomationSettings = async (
+  payload: AllegroAutomationSettings,
+): Promise<AllegroAutomationSettings> => {
+  const response = await allegroClient.put<AllegroAutomationSettings>('/automation-settings', payload);
+  return response.data;
+};
+
+export const fetchHealthStatus = async (): Promise<AllegroHealthStatus> => {
+  const response = await allegroClient.get<AllegroHealthStatus>('/health');
+  return response.data;
+};

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -19,7 +19,7 @@ const Footer = () => {
             <ul className={styles.linkList}>
               <li><a href="/catalog" className={styles.link}>Каталог товаров</a></li>
               <li><a href="/warehouses" className={styles.link}>Управление складами</a></li>
-              <li><a href="/orders" className={styles.link}>Заказы</a></li>
+              <li><a href="/allegro" className={styles.link}>Allegro backup</a></li>
             </ul>
           </div>
           

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -35,6 +35,9 @@ const Header = ({ user, onLogout }: HeaderProps) => {
           <Link to="/warehouses" className={styles.navLink}>
             Склады
           </Link>
+          <Link to="/allegro" className={styles.navLink}>
+            Allegro backup
+          </Link>
           {user?.permissions.is_admin && (
             <Link to="/admin" className={styles.navLink}>
               Администрирование

--- a/frontend/src/components/allegro/AllegroOverview.module.css
+++ b/frontend/src/components/allegro/AllegroOverview.module.css
@@ -1,0 +1,168 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.summaryCards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cardTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cardValue {
+  font-size: 32px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.cardSubtitle {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.syncPanel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.syncCard {
+  background: #0f172a;
+  color: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.syncCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.3), transparent 60%);
+  pointer-events: none;
+}
+
+.syncHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.syncTitle {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.syncButton {
+  background: #38bdf8;
+  color: #0f172a;
+  border: none;
+  border-radius: 9999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.syncButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.syncButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
+}
+
+.healthList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.healthItem {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.healthInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.healthTitle {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.healthTimestamp {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.statusBadge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.statusOk {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.statusDegraded {
+  background: rgba(249, 115, 22, 0.15);
+  color: #c2410c;
+}
+
+.statusDown {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.overviewSection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionTitle {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+}

--- a/frontend/src/components/allegro/AllegroOverview.tsx
+++ b/frontend/src/components/allegro/AllegroOverview.tsx
@@ -1,0 +1,139 @@
+import { formatDistanceToNow } from 'date-fns';
+import { ru } from 'date-fns/locale';
+import {
+  AllegroHealthStatus,
+  AllegroSyncStats,
+  AllegroToken,
+  TriggerSyncPayload,
+} from '../../types/allegro';
+import styles from './AllegroOverview.module.css';
+
+interface AllegroOverviewProps {
+  tokens: AllegroToken[];
+  stats?: AllegroSyncStats;
+  health?: AllegroHealthStatus;
+  syncing: boolean;
+  onManualSync: (payload?: TriggerSyncPayload) => Promise<void>;
+}
+
+const statusClass = (status: 'ok' | 'degraded' | 'down') => {
+  switch (status) {
+    case 'ok':
+      return `${styles.statusBadge} ${styles.statusOk}`;
+    case 'degraded':
+      return `${styles.statusBadge} ${styles.statusDegraded}`;
+    case 'down':
+    default:
+      return `${styles.statusBadge} ${styles.statusDown}`;
+  }
+};
+
+const AllegroOverview = ({ tokens, stats, health, syncing, onManualSync }: AllegroOverviewProps) => {
+  const activeTokens = tokens.filter((token) => token.status === 'active').length;
+  const defaultToken = tokens.find((token) => token.is_default);
+
+  const handleManualSync = async () => {
+    await onManualSync();
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.summaryCards}>
+        <div className={styles.card}>
+          <span className={styles.cardTitle}>Активные токены</span>
+          <span className={styles.cardValue}>{activeTokens}</span>
+          <span className={styles.cardSubtitle}>
+            {tokens.length > 0
+              ? `Всего подключено ${tokens.length} аккаунтов`
+              : 'Нет подключенных аккаунтов Allegro'}
+          </span>
+        </div>
+
+        <div className={styles.card}>
+          <span className={styles.cardTitle}>Заказы сегодня</span>
+          <span className={styles.cardValue}>{stats?.orders_synced_today ?? 0}</span>
+          <span className={styles.cardSubtitle}>
+            {stats?.last_sync_at
+              ? `Последняя синхронизация ${formatDistanceToNow(new Date(stats.last_sync_at), {
+                  addSuffix: true,
+                  locale: ru,
+                })}`
+              : 'Синхронизаций еще не было'}
+          </span>
+        </div>
+
+        <div className={styles.card}>
+          <span className={styles.cardTitle}>Заказы в обработке</span>
+          <span className={styles.cardValue}>{stats?.orders_pending ?? 0}</span>
+          <span className={styles.cardSubtitle}>Нужно подтвердить или отправить</span>
+        </div>
+
+        <div className={styles.card}>
+          <span className={styles.cardTitle}>Неудачные синхронизации</span>
+          <span className={styles.cardValue}>{stats?.failed_syncs_today ?? 0}</span>
+          <span className={styles.cardSubtitle}>Ошибки за последние 24 часа</span>
+        </div>
+      </div>
+
+      <div className={styles.syncPanel}>
+        <div className={styles.syncCard}>
+          <div className={styles.syncHeader}>
+            <span className={styles.syncTitle}>Ручная синхронизация</span>
+            <button
+              className={styles.syncButton}
+              onClick={handleManualSync}
+              disabled={syncing || tokens.length === 0}
+            >
+              {syncing ? 'Синхронизация…' : 'Запустить' }
+            </button>
+          </div>
+          <p>
+            Запускает немедленный импорт заказов из Allegro orders backup для всех активных токенов.
+            Используйте при возникновении расхождений или перед закрытием дня.
+          </p>
+          {defaultToken && (
+            <p>
+              Токен по умолчанию: <strong>{defaultToken.account_name}</strong>
+            </p>
+          )}
+        </div>
+
+        <div className={`${styles.syncCard}`}>
+          <div className={styles.syncHeader}>
+            <span className={styles.syncTitle}>Статус систем</span>
+          </div>
+          <div className={styles.healthList}>
+            {(health?.services ?? []).length > 0 ? (
+              health?.services?.map((service) => (
+                <div key={service.service} className={styles.healthItem}>
+                  <div className={styles.healthInfo}>
+                    <span className={styles.healthTitle}>{service.service}</span>
+                    <span className={styles.healthTimestamp}>
+                      Проверено {formatDistanceToNow(new Date(service.last_check_at), {
+                        addSuffix: true,
+                        locale: ru,
+                      })}
+                    </span>
+                  </div>
+                  <span className={statusClass(service.status)}>
+                    {service.status === 'ok'
+                      ? 'В норме'
+                      : service.status === 'degraded'
+                        ? 'Замедление'
+                        : 'Не работает'}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <div className={styles.healthItem}>
+                <span className={styles.healthTitle}>Нет данных о статусе системы</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AllegroOverview;

--- a/frontend/src/components/allegro/AutomationSettings.module.css
+++ b/frontend/src/components/allegro/AutomationSettings.module.css
@@ -1,0 +1,97 @@
+.container {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.description {
+  color: #64748b;
+  font-size: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.badgeGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.input,
+.select,
+.textarea {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+}
+
+.textarea {
+  min-height: 80px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.button {
+  background: linear-gradient(135deg, #34d399, #10b981);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.secondaryButton {
+  background: transparent;
+  border: none;
+  color: #64748b;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.helper {
+  font-size: 12px;
+  color: #94a3b8;
+}

--- a/frontend/src/components/allegro/AutomationSettings.tsx
+++ b/frontend/src/components/allegro/AutomationSettings.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react';
+import {
+  AllegroAutomationSettings,
+  AllegroOrderStatus,
+} from '../../types/allegro';
+import styles from './AutomationSettings.module.css';
+
+interface AutomationSettingsProps {
+  initialSettings?: AllegroAutomationSettings;
+  onSave: (settings: AllegroAutomationSettings) => Promise<void>;
+}
+
+const ALL_STATUSES: AllegroOrderStatus[] = ['new', 'processing', 'ready_for_shipment', 'shipped', 'cancelled', 'returned'];
+
+const statusLabel = (status: AllegroOrderStatus) => {
+  switch (status) {
+    case 'new':
+      return 'Новые';
+    case 'processing':
+      return 'В обработке';
+    case 'ready_for_shipment':
+      return 'Готовы к отгрузке';
+    case 'shipped':
+      return 'Отгружены';
+    case 'cancelled':
+      return 'Отмененные';
+    case 'returned':
+      return 'Возвраты';
+    default:
+      return status;
+  }
+};
+
+const AutomationSettings = ({ initialSettings, onSave }: AutomationSettingsProps) => {
+  const [settings, setSettings] = useState<AllegroAutomationSettings>(
+    initialSettings ?? {
+      auto_sync_enabled: true,
+      sync_interval_minutes: 30,
+      order_states_to_import: ['new', 'processing', 'ready_for_shipment'],
+      notify_on_failures: true,
+      notify_emails: [],
+    },
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialSettings) {
+      setSettings(initialSettings);
+    }
+  }, [initialSettings]);
+
+  const handleStatusToggle = (status: AllegroOrderStatus) => {
+    setSettings((prev) => {
+      const exists = prev.order_states_to_import.includes(status);
+      return {
+        ...prev,
+        order_states_to_import: exists
+          ? prev.order_states_to_import.filter((s) => s !== status)
+          : [...prev.order_states_to_import, status],
+      };
+    });
+  };
+
+  const handleEmailsChange = (value: string) => {
+    const emails = value
+      .split(',')
+      .map((email) => email.trim())
+      .filter((email) => email.length > 0);
+    setSettings((prev) => ({ ...prev, notify_emails: emails }));
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSave(settings);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось сохранить настройки.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className={styles.container}>
+      <div>
+        <h3 className={styles.title}>Автоматизация синхронизации</h3>
+        <p className={styles.description}>
+          Настройте расписание и уведомления для фоновой синхронизации Allegro orders backup.
+        </p>
+      </div>
+
+      <label className={styles.checkboxRow}>
+        <input
+          type="checkbox"
+          checked={settings.auto_sync_enabled}
+          onChange={(event) => setSettings((prev) => ({ ...prev, auto_sync_enabled: event.target.checked }))}
+        />
+        Автоматически запускать синхронизацию каждые {settings.sync_interval_minutes} минут
+      </label>
+
+      <div className={styles.field}>
+        <span className={styles.label}>Интервал синхронизации (минуты)</span>
+        <input
+          type="number"
+          min={5}
+          step={5}
+          className={styles.input}
+          value={settings.sync_interval_minutes}
+          onChange={(event) => setSettings((prev) => ({ ...prev, sync_interval_minutes: Number(event.target.value) }))}
+        />
+        <span className={styles.helper}>Рекомендуемый интервал — 15–30 минут.</span>
+      </div>
+
+      <div className={styles.field}>
+        <span className={styles.label}>Состояния заказов для импорта</span>
+        <div className={styles.badgeGroup}>
+          {ALL_STATUSES.map((status) => (
+            <button
+              key={status}
+              type="button"
+              className={styles.badge}
+              style={{
+                opacity: settings.order_states_to_import.includes(status) ? 1 : 0.4,
+              }}
+              onClick={() => handleStatusToggle(status)}
+            >
+              {statusLabel(status)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <label className={styles.checkboxRow}>
+        <input
+          type="checkbox"
+          checked={settings.notify_on_failures}
+          onChange={(event) => setSettings((prev) => ({ ...prev, notify_on_failures: event.target.checked }))}
+        />
+        Отправлять уведомления при ошибках синхронизации
+      </label>
+
+      <div className={styles.field}>
+        <span className={styles.label}>Email для уведомлений</span>
+        <textarea
+          className={styles.textarea}
+          placeholder="admin@example.com, support@example.com"
+          value={settings.notify_emails.join(', ')}
+          onChange={(event) => handleEmailsChange(event.target.value)}
+        />
+        <span className={styles.helper}>Укажите через запятую несколько адресов.</span>
+      </div>
+
+      {error && <div className={styles.helper} style={{ color: '#b91c1c' }}>{error}</div>}
+
+      <div className={styles.actions}>
+        <button className={styles.secondaryButton} type="button" onClick={() => initialSettings && setSettings(initialSettings)}>
+          Сбросить
+        </button>
+        <button className={styles.button} type="button" onClick={handleSave} disabled={isSaving}>
+          {isSaving ? 'Сохраняем…' : 'Сохранить настройки'}
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default AutomationSettings;

--- a/frontend/src/components/allegro/OrderDetailsDrawer.module.css
+++ b/frontend/src/components/allegro/OrderDetailsDrawer.module.css
@@ -1,0 +1,124 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 60;
+}
+
+.drawer {
+  background: #fff;
+  width: min(520px, 90vw);
+  height: 100%;
+  padding: 24px;
+  border-radius: 24px 0 0 24px;
+  box-shadow: -12px 0 32px rgba(15, 23, 42, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.closeButton {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: #334155;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.keyValue {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  color: #475569;
+}
+
+.itemsList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: #f8fafc;
+  padding: 12px;
+  border-radius: 12px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.itemRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.itemRow:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+}
+
+.footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.button {
+  background: #0f172a;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.secondaryButton {
+  background: transparent;
+  color: #6366f1;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/frontend/src/components/allegro/OrderDetailsDrawer.tsx
+++ b/frontend/src/components/allegro/OrderDetailsDrawer.tsx
@@ -1,0 +1,167 @@
+import { format } from 'date-fns';
+import { ru } from 'date-fns/locale';
+import { AllegroOrder } from '../../types/allegro';
+import styles from './OrderDetailsDrawer.module.css';
+
+interface OrderDetailsDrawerProps {
+  order: AllegroOrder;
+  onClose: () => void;
+}
+
+const OrderDetailsDrawer = ({ order, onClose }: OrderDetailsDrawerProps) => {
+  const statusLabel = () => {
+    switch (order.status) {
+      case 'new':
+        return 'Новый';
+      case 'processing':
+        return 'В обработке';
+      case 'ready_for_shipment':
+        return 'Готов к отгрузке';
+      case 'shipped':
+        return 'Отгружен';
+      case 'cancelled':
+        return 'Отменен';
+      case 'returned':
+        return 'Возврат';
+      default:
+        return order.status;
+    }
+  };
+
+  const paymentLabel = () => {
+    switch (order.payment_status) {
+      case 'paid':
+        return 'Оплачено';
+      case 'pending':
+        return 'Ожидает оплаты';
+      case 'refunded':
+        return 'Возврат';
+      case 'failed':
+        return 'Ошибка оплаты';
+      default:
+        return order.payment_status;
+    }
+  };
+
+  const fulfillmentLabel = () => {
+    switch (order.fulfillment_status) {
+      case 'pending':
+        return 'Не начат';
+      case 'in_progress':
+        return 'В процессе';
+      case 'fulfilled':
+        return 'Отгружен';
+      case 'cancelled':
+        return 'Отменен';
+      default:
+        return order.fulfillment_status;
+    }
+  };
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.drawer}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>Заказ {order.marketplace_order_id}</h3>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Закрыть">
+            ×
+          </button>
+        </div>
+
+        <div className={styles.section}>
+          <span className={styles.sectionTitle}>Информация о заказе</span>
+          <div className={styles.keyValue}>
+            <span>Создан</span>
+            <span>{format(new Date(order.created_at), 'd MMMM yyyy HH:mm', { locale: ru })}</span>
+          </div>
+          <div className={styles.keyValue}>
+            <span>Статус</span>
+            <span className={styles.badge}>{statusLabel()}</span>
+          </div>
+          <div className={styles.keyValue}>
+            <span>Оплата</span>
+            <span>{paymentLabel()}</span>
+          </div>
+          <div className={styles.keyValue}>
+            <span>Фулфилмент</span>
+            <span>{fulfillmentLabel()}</span>
+          </div>
+          {order.last_synced_at && (
+            <div className={styles.keyValue}>
+              <span>Последняя синхронизация</span>
+              <span>{format(new Date(order.last_synced_at), 'd MMM yyyy HH:mm', { locale: ru })}</span>
+            </div>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <span className={styles.sectionTitle}>Покупатель</span>
+          <div className={styles.keyValue}>
+            <span>Имя</span>
+            <span>{order.buyer.name}</span>
+          </div>
+          {order.buyer.email && (
+            <div className={styles.keyValue}>
+              <span>Email</span>
+              <span>{order.buyer.email}</span>
+            </div>
+          )}
+          {order.buyer.phone && (
+            <div className={styles.keyValue}>
+              <span>Телефон</span>
+              <span>{order.buyer.phone}</span>
+            </div>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <span className={styles.sectionTitle}>Товары</span>
+          <div className={styles.itemsList}>
+            {order.items.map((item) => (
+              <div key={item.line_item_id} className={styles.itemRow}>
+                <div>
+                  <strong>{item.name}</strong>
+                  <span> • SKU: {item.sku}</span>
+                </div>
+                <div>
+                  Количество: {item.quantity} × {item.unit_price} {item.currency}
+                </div>
+                {item.fulfillment_status && <div>Фулфилмент: {item.fulfillment_status}</div>}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <span className={styles.sectionTitle}>Отгрузка</span>
+          <div className={styles.keyValue}>
+            <span>Метод доставки</span>
+            <span>{order.delivery_method ?? '—'}</span>
+          </div>
+          <div className={styles.keyValue}>
+            <span>Трек-номер</span>
+            <span>{order.shipping_tracking_number ?? '—'}</span>
+          </div>
+        </div>
+
+        {order.notes && (
+          <div className={styles.section}>
+            <span className={styles.sectionTitle}>Заметки</span>
+            <div>{order.notes}</div>
+          </div>
+        )}
+
+        <div className={styles.footer}>
+          <button className={styles.secondaryButton} onClick={onClose}>
+            Закрыть
+          </button>
+          <button className={styles.button} onClick={onClose}>
+            Перейти к заказу в Allegro
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrderDetailsDrawer;

--- a/frontend/src/components/allegro/OrdersPanel.module.css
+++ b/frontend/src/components/allegro/OrdersPanel.module.css
@@ -1,0 +1,162 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+}
+
+.filterField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #64748b;
+  letter-spacing: 0.04em;
+}
+
+.select,
+.input,
+.dateInput {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  transition: border-color 0.2s ease;
+}
+
+.select:focus,
+.input:focus,
+.dateInput:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.05);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 800px;
+}
+
+.table thead {
+  background: #f8fafc;
+}
+
+.table th {
+  text-align: left;
+  padding: 14px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.table td {
+  padding: 16px;
+  border-top: 1px solid rgba(226, 232, 240, 0.6);
+  font-size: 14px;
+  color: #0f172a;
+}
+
+.row {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.row:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.statusBadge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.statusNew {
+  background: rgba(56, 189, 248, 0.15);
+  color: #0369a1;
+}
+
+.statusProcessing {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.statusReady_for_shipment,
+.statusReadyForShipment {
+  background: rgba(250, 204, 21, 0.2);
+  color: #b45309;
+}
+
+.statusShipped {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.statusCancelled {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.statusReturned {
+  background: rgba(249, 115, 22, 0.15);
+  color: #c2410c;
+}
+
+.refreshRow {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.refreshButton {
+  background: #0f172a;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.clearButton {
+  background: transparent;
+  color: #64748b;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.emptyState {
+  padding: 32px;
+  text-align: center;
+  color: #64748b;
+}

--- a/frontend/src/components/allegro/OrdersPanel.tsx
+++ b/frontend/src/components/allegro/OrdersPanel.tsx
@@ -1,0 +1,235 @@
+import { useMemo } from 'react';
+import { format } from 'date-fns';
+import { ru } from 'date-fns/locale';
+import { AllegroOrder, AllegroOrderFilters, AllegroToken } from '../../types/allegro';
+import styles from './OrdersPanel.module.css';
+
+interface OrdersPanelProps {
+  orders: AllegroOrder[];
+  loading: boolean;
+  tokens: AllegroToken[];
+  filters: AllegroOrderFilters;
+  onFiltersChange: (filters: AllegroOrderFilters) => void;
+  onRefresh: () => void;
+  onSelectOrder: (order: AllegroOrder) => void;
+}
+
+const formatMoney = (amount: number, currency: string) =>
+  new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+const statusBadgeClass = (status: AllegroOrder['status']) => {
+  switch (status) {
+    case 'new':
+      return `${styles.statusBadge} ${styles.statusNew}`;
+    case 'processing':
+      return `${styles.statusBadge} ${styles.statusProcessing}`;
+    case 'ready_for_shipment':
+      return `${styles.statusBadge} ${styles.statusReady_for_shipment}`;
+    case 'shipped':
+      return `${styles.statusBadge} ${styles.statusShipped}`;
+    case 'cancelled':
+      return `${styles.statusBadge} ${styles.statusCancelled}`;
+    case 'returned':
+      return `${styles.statusBadge} ${styles.statusReturned}`;
+    default:
+      return styles.statusBadge;
+  }
+};
+
+const OrdersPanel = ({ orders, loading, tokens, filters, onFiltersChange, onRefresh, onSelectOrder }: OrdersPanelProps) => {
+  const tokenOptions = useMemo(() => [{ token_id: 'all', account_name: 'Все аккаунты' }, ...tokens], [tokens]);
+
+  const handleChange = (field: keyof AllegroOrderFilters, value: string) => {
+    const nextFilters: AllegroOrderFilters = { ...filters };
+    if (!value || value === 'all') {
+      delete nextFilters[field];
+    } else {
+      nextFilters[field] = value as any;
+    }
+    onFiltersChange(nextFilters);
+  };
+
+  const handleDateChange = (field: keyof AllegroOrderFilters, value: string) => {
+    const nextFilters: AllegroOrderFilters = { ...filters, [field]: value || undefined };
+    if (!value) {
+      delete nextFilters[field];
+    }
+    onFiltersChange(nextFilters);
+  };
+
+  const clearFilters = () => {
+    onFiltersChange({});
+  };
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.filters}>
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="token-select">Аккаунт</label>
+          <select
+            id="token-select"
+            className={styles.select}
+            value={filters.token_id ?? 'all'}
+            onChange={(event) => handleChange('token_id', event.target.value)}
+          >
+            {tokenOptions.map((token) => (
+              <option key={token.token_id} value={token.token_id === 'all' ? 'all' : token.token_id}>
+                {token.account_name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="status-select">Статус заказа</label>
+          <select
+            id="status-select"
+            className={styles.select}
+            value={filters.status ?? 'all'}
+            onChange={(event) => handleChange('status', event.target.value)}
+          >
+            <option value="all">Все</option>
+            <option value="new">Новые</option>
+            <option value="processing">В обработке</option>
+            <option value="ready_for_shipment">Готовы к отгрузке</option>
+            <option value="shipped">Отгружены</option>
+            <option value="cancelled">Отменены</option>
+            <option value="returned">Возвраты</option>
+          </select>
+        </div>
+
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="payment-select">Оплата</label>
+          <select
+            id="payment-select"
+            className={styles.select}
+            value={filters.payment_status ?? 'all'}
+            onChange={(event) => handleChange('payment_status', event.target.value)}
+          >
+            <option value="all">Все</option>
+            <option value="paid">Оплачено</option>
+            <option value="pending">Ожидает</option>
+            <option value="refunded">Возврат</option>
+            <option value="failed">Ошибка</option>
+          </select>
+        </div>
+
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="fulfillment-select">Фулфилмент</label>
+          <select
+            id="fulfillment-select"
+            className={styles.select}
+            value={filters.fulfillment_status ?? 'all'}
+            onChange={(event) => handleChange('fulfillment_status', event.target.value)}
+          >
+            <option value="all">Все</option>
+            <option value="pending">Не начат</option>
+            <option value="in_progress">В процессе</option>
+            <option value="fulfilled">Отгружен</option>
+            <option value="cancelled">Отменен</option>
+          </select>
+        </div>
+
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="date-from">Дата с</label>
+          <input
+            id="date-from"
+            type="date"
+            className={styles.dateInput}
+            value={filters.created_from ?? ''}
+            onChange={(event) => handleDateChange('created_from', event.target.value)}
+          />
+        </div>
+
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="date-to">Дата по</label>
+          <input
+            id="date-to"
+            type="date"
+            className={styles.dateInput}
+            value={filters.created_to ?? ''}
+            onChange={(event) => handleDateChange('created_to', event.target.value)}
+          />
+        </div>
+
+        <div className={styles.filterField}>
+          <label className={styles.label} htmlFor="search">Поиск</label>
+          <input
+            id="search"
+            className={styles.input}
+            placeholder="Заказ, email, телефон"
+            value={filters.search ?? ''}
+            onChange={(event) => handleChange('search', event.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className={styles.refreshRow}>
+        <button className={styles.clearButton} onClick={clearFilters}>Сбросить фильтры</button>
+        <button className={styles.refreshButton} onClick={onRefresh} disabled={loading}>
+          {loading ? 'Обновляем…' : 'Обновить список'}
+        </button>
+      </div>
+
+      <div className={styles.tableWrapper}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Дата</th>
+              <th>Allegro ID</th>
+              <th>Клиент</th>
+              <th>Статус</th>
+              <th>Сумма</th>
+              <th>Оплата</th>
+              <th>Фулфилмент</th>
+              <th>Токен</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.length === 0 && !loading ? (
+              <tr>
+                <td colSpan={8} className={styles.emptyState}>Заказы не найдены</td>
+              </tr>
+            ) : (
+              orders.map((order) => (
+                <tr key={order.order_id} className={styles.row} onClick={() => onSelectOrder(order)}>
+                  <td>{format(new Date(order.created_at), 'd MMM yyyy HH:mm', { locale: ru })}</td>
+                  <td>{order.marketplace_order_id}</td>
+                  <td>
+                    <div>{order.buyer.name}</div>
+                    <div>{order.buyer.email}</div>
+                  </td>
+                  <td>
+                    <span className={statusBadgeClass(order.status)}>
+                      {order.status === 'new'
+                        ? 'Новый'
+                        : order.status === 'processing'
+                          ? 'В обработке'
+                          : order.status === 'ready_for_shipment'
+                            ? 'Готов к отгрузке'
+                            : order.status === 'shipped'
+                              ? 'Отгружен'
+                              : order.status === 'cancelled'
+                                ? 'Отменен'
+                                : 'Возврат'}
+                    </span>
+                  </td>
+                  <td>{formatMoney(order.total_amount, order.currency)}</td>
+                  <td>{order.payment_status === 'paid' ? 'Оплачено' : order.payment_status === 'pending' ? 'Ожидает' : order.payment_status === 'refunded' ? 'Возврат' : 'Ошибка'}</td>
+                  <td>{order.fulfillment_status === 'pending' ? 'Не начат' : order.fulfillment_status === 'in_progress' ? 'В процессе' : order.fulfillment_status === 'fulfilled' ? 'Отгружен' : 'Отменен'}</td>
+                  <td>{tokens.find((token) => token.token_id === order.token_id)?.account_name ?? '—'}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+export default OrdersPanel;

--- a/frontend/src/components/allegro/SyncLogsPanel.module.css
+++ b/frontend/src/components/allegro/SyncLogsPanel.module.css
@@ -1,0 +1,76 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.select {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+.tableWrapper {
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+  text-align: left;
+  font-size: 13px;
+}
+
+.badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.warning {
+  background: rgba(250, 204, 21, 0.2);
+  color: #b45309;
+}
+
+.error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.info {
+  background: rgba(96, 165, 250, 0.2);
+  color: #1d4ed8;
+}
+
+.emptyState {
+  padding: 24px;
+  text-align: center;
+  color: #64748b;
+}

--- a/frontend/src/components/allegro/SyncLogsPanel.tsx
+++ b/frontend/src/components/allegro/SyncLogsPanel.tsx
@@ -1,0 +1,116 @@
+import { formatDistanceToNow } from 'date-fns';
+import { ru } from 'date-fns/locale';
+import { AllegroSyncLog, AllegroToken, SyncLogsFilters } from '../../types/allegro';
+import styles from './SyncLogsPanel.module.css';
+
+interface SyncLogsPanelProps {
+  logs: AllegroSyncLog[];
+  tokens: AllegroToken[];
+  filters: SyncLogsFilters;
+  onFiltersChange: (filters: SyncLogsFilters) => void;
+}
+
+const statusClass = (status: AllegroSyncLog['status']) => {
+  switch (status) {
+    case 'success':
+      return `${styles.badge} ${styles.success}`;
+    case 'warning':
+      return `${styles.badge} ${styles.warning}`;
+    case 'error':
+      return `${styles.badge} ${styles.error}`;
+    default:
+      return `${styles.badge} ${styles.info}`;
+  }
+};
+
+const SyncLogsPanel = ({ logs, tokens, filters, onFiltersChange }: SyncLogsPanelProps) => {
+  const handleChange = (field: keyof SyncLogsFilters, value: string) => {
+    const next = { ...filters };
+    if (!value || value === 'all') {
+      delete next[field];
+    } else {
+      next[field] = value as any;
+    }
+    onFiltersChange(next);
+  };
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.filters}>
+        <select
+          className={styles.select}
+          value={filters.token_id ?? 'all'}
+          onChange={(event) => handleChange('token_id', event.target.value)}
+        >
+          <option value="all">Все токены</option>
+          {tokens.map((token) => (
+            <option key={token.token_id} value={token.token_id}>
+              {token.account_name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          className={styles.select}
+          value={filters.status ?? 'all'}
+          onChange={(event) => handleChange('status', event.target.value)}
+        >
+          <option value="all">Все статусы</option>
+          <option value="success">Успех</option>
+          <option value="warning">Предупреждение</option>
+          <option value="error">Ошибка</option>
+          <option value="info">Инфо</option>
+        </select>
+
+        <select
+          className={styles.select}
+          value={filters.event_type ?? 'all'}
+          onChange={(event) => handleChange('event_type', event.target.value)}
+        >
+          <option value="all">Все события</option>
+          <option value="orders_sync">Синхронизация заказов</option>
+          <option value="token_refresh">Обновление токена</option>
+          <option value="webhook">Webhook</option>
+          <option value="maintenance">Сервисные работы</option>
+        </select>
+      </div>
+
+      <div className={styles.tableWrapper}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Время</th>
+              <th>Токен</th>
+              <th>Тип</th>
+              <th>Статус</th>
+              <th>Сообщение</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.length === 0 ? (
+              <tr>
+                <td colSpan={5} className={styles.emptyState}>
+                  Записей нет
+                </td>
+              </tr>
+            ) : (
+              logs.map((log) => (
+                <tr key={log.log_id}>
+                  <td>{formatDistanceToNow(new Date(log.created_at), { addSuffix: true, locale: ru })}</td>
+                  <td>{log.token_account_name ?? '—'}</td>
+                  <td>{log.event_type}</td>
+                  <td>
+                    <span className={statusClass(log.status)}>{log.status}</span>
+                  </td>
+                  <td>{log.message}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+export default SyncLogsPanel;

--- a/frontend/src/components/allegro/TokenManager.module.css
+++ b/frontend/src/components/allegro/TokenManager.module.css
@@ -1,0 +1,258 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.3);
+}
+
+.tokensGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.tokenCard {
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+}
+
+.tokenHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tokenName {
+  font-weight: 600;
+  font-size: 16px;
+  color: #0f172a;
+}
+
+.badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.statusActive {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+
+.statusExpired {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.statusPending {
+  background: rgba(56, 189, 248, 0.15);
+  color: #0284c7;
+}
+
+.statusError {
+  background: rgba(249, 115, 22, 0.15);
+  color: #c2410c;
+}
+
+.metaRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #475569;
+}
+
+.tokenActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.secondaryButton {
+  background: #f8fafc;
+  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.secondaryButton:hover {
+  background: #e2e8f0;
+}
+
+.dangerButton {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dangerButton:hover {
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.defaultBadge {
+  background: rgba(59, 130, 246, 0.15);
+  color: #2563eb;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.errorBox {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 10px;
+  padding: 12px;
+  color: #b91c1c;
+  font-size: 13px;
+}
+
+.emptyState {
+  background: #fff;
+  border-radius: 14px;
+  padding: 40px;
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+  text-align: center;
+  color: #475569;
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  width: min(480px, 92vw);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modalTitle {
+  font-size: 18px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #475569;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.input {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 10px 12px;
+  font-size: 14px;
+  transition: border-color 0.2s ease;
+}
+
+.input:focus {
+  border-color: #6366f1;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.cancelButton {
+  background: transparent;
+  border: none;
+  color: #64748b;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 8px 12px;
+}
+
+.saveButton {
+  background: #0f172a;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.helperText {
+  font-size: 12px;
+  color: #94a3b8;
+}

--- a/frontend/src/components/allegro/TokenManager.tsx
+++ b/frontend/src/components/allegro/TokenManager.tsx
@@ -1,0 +1,260 @@
+import { useMemo, useState, type FormEvent } from 'react';
+import { format } from 'date-fns';
+import { ru } from 'date-fns/locale';
+import {
+  AllegroToken,
+  CreateTokenPayload,
+  UpdateTokenPayload,
+} from '../../types/allegro';
+import styles from './TokenManager.module.css';
+
+interface TokenManagerProps {
+  tokens: AllegroToken[];
+  loading: boolean;
+  onCreate: (payload: CreateTokenPayload) => Promise<void>;
+  onUpdate: (tokenId: string, payload: UpdateTokenPayload) => Promise<void>;
+  onDelete: (tokenId: string) => Promise<void>;
+  onRefresh: (tokenId: string) => Promise<void>;
+  onToggleActive: (tokenId: string, isActive: boolean) => Promise<void>;
+}
+
+interface TokenFormState {
+  account_name: string;
+  authorization_code: string;
+  is_default: boolean;
+}
+
+const initialFormState: TokenFormState = {
+  account_name: '',
+  authorization_code: '',
+  is_default: false,
+};
+
+const statusBadgeClass = (status: AllegroToken['status']) => {
+  switch (status) {
+    case 'active':
+      return `${styles.badge} ${styles.statusActive}`;
+    case 'pending':
+      return `${styles.badge} ${styles.statusPending}`;
+    case 'error':
+      return `${styles.badge} ${styles.statusError}`;
+    case 'expired':
+    case 'revoked':
+    default:
+      return `${styles.badge} ${styles.statusExpired}`;
+  }
+};
+
+const TokenManager = ({
+  tokens,
+  loading,
+  onCreate,
+  onUpdate,
+  onDelete,
+  onRefresh,
+  onToggleActive,
+}: TokenManagerProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [formState, setFormState] = useState<TokenFormState>(initialFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sortedTokens = useMemo(
+    () =>
+      [...tokens].sort((a, b) => {
+        if (a.is_default) return -1;
+        if (b.is_default) return 1;
+        return a.account_name.localeCompare(b.account_name, 'ru');
+      }),
+    [tokens],
+  );
+
+  const openModal = () => {
+    setFormState(initialFormState);
+    setError(null);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleChange = (field: keyof TokenFormState, value: string | boolean) => {
+    setFormState((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onCreate({
+        account_name: formState.account_name,
+        authorization_code: formState.authorization_code,
+        is_default: formState.is_default,
+      });
+      setIsModalOpen(false);
+      setFormState(initialFormState);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось создать токен.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.header}>
+        <div>
+          <h2 className={styles.title}>Подключенные аккаунты Allegro</h2>
+          <p className={styles.helperText}>
+            Управляйте OAuth-токенами, которые используются для синхронизации заказов через Allegro orders backup.
+          </p>
+        </div>
+        <div className={styles.actions}>
+          <button className={styles.primaryButton} onClick={openModal} disabled={loading}>
+            Подключить новый аккаунт
+          </button>
+        </div>
+      </div>
+
+      {tokens.length === 0 && !loading ? (
+        <div className={styles.emptyState}>
+          <h3>Нет подключенных токенов</h3>
+          <p>Добавьте токен Allegro, чтобы начать резервное копирование и импорт заказов в систему.</p>
+        </div>
+      ) : (
+        <div className={styles.tokensGrid}>
+          {sortedTokens.map((token) => (
+            <article key={token.token_id} className={styles.tokenCard}>
+              <div className={styles.tokenHeader}>
+                <div>
+                  <div className={styles.tokenName}>{token.account_name}</div>
+                  {token.is_default && <span className={styles.defaultBadge}>По умолчанию</span>}
+                </div>
+                <span className={statusBadgeClass(token.status)}>
+                  {token.status === 'active'
+                    ? 'Активен'
+                    : token.status === 'pending'
+                      ? 'Обновляется'
+                      : token.status === 'error'
+                        ? 'Ошибка'
+                        : 'Неактивен'}
+                </span>
+              </div>
+
+              <div className={styles.metaRow}>
+                <span>Создан: {format(new Date(token.created_at), 'd MMMM yyyy', { locale: ru })}</span>
+                <span>Экспортировано заказов: {token.orders_imported}</span>
+              </div>
+
+              <div className={styles.metaRow}>
+                <span>Истекает: {format(new Date(token.expires_at), 'd MMMM yyyy HH:mm', { locale: ru })}</span>
+                <span>Клиент: {token.client_id}</span>
+              </div>
+
+              {token.last_sync_at && (
+                <div className={styles.metaRow}>
+                  <span>Последняя синхронизация:</span>
+                  <span>{format(new Date(token.last_sync_at), 'd MMMM yyyy HH:mm', { locale: ru })}</span>
+                </div>
+              )}
+
+              {token.last_error && (
+                <div className={styles.errorBox}>Последняя ошибка: {token.last_error}</div>
+              )}
+
+              <div className={styles.tokenActions}>
+                <button
+                  className={styles.secondaryButton}
+                  onClick={() => onRefresh(token.token_id)}
+                  disabled={loading}
+                >
+                  Обновить токен
+                </button>
+                <button
+                  className={styles.secondaryButton}
+                  onClick={() =>
+                    onToggleActive(token.token_id, !(token.status === 'active' || token.status === 'pending'))
+                  }
+                  disabled={loading}
+                >
+                  {token.status === 'active' || token.status === 'pending' ? 'Деактивировать' : 'Активировать'}
+                </button>
+                <button
+                  className={styles.secondaryButton}
+                  onClick={() => onUpdate(token.token_id, { is_default: !token.is_default })}
+                  disabled={loading || token.status !== 'active'}
+                >
+                  {token.is_default ? 'Сделать вторичным' : 'Сделать основным'}
+                </button>
+                <button className={styles.dangerButton} onClick={() => onDelete(token.token_id)} disabled={loading}>
+                  Удалить
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {isModalOpen && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <h3 className={styles.modalTitle}>Добавить токен Allegro</h3>
+            <form className={styles.form} onSubmit={handleSubmit}>
+              <label className={styles.label}>
+                Название аккаунта
+                <input
+                  className={styles.input}
+                  value={formState.account_name}
+                  onChange={(event) => handleChange('account_name', event.target.value)}
+                  required
+                />
+              </label>
+
+              <label className={styles.label}>
+                Авторизационный код Allegro
+                <textarea
+                  className={styles.input}
+                  value={formState.authorization_code}
+                  onChange={(event) => handleChange('authorization_code', event.target.value)}
+                  required
+                  rows={4}
+                />
+                <span className={styles.helperText}>
+                  Получите код в приложении Allegro и вставьте его сюда для обмена на токен доступа.
+                </span>
+              </label>
+
+              <label className={styles.checkboxRow}>
+                <input
+                  type="checkbox"
+                  checked={formState.is_default}
+                  onChange={(event) => handleChange('is_default', event.target.checked)}
+                />
+                Сделать токен основным для всех новых заказов
+              </label>
+
+              {error && <div className={styles.errorBox}>{error}</div>}
+
+              <div className={styles.modalActions}>
+                <button type="button" className={styles.cancelButton} onClick={closeModal} disabled={isSubmitting}>
+                  Отменить
+                </button>
+                <button type="submit" className={styles.saveButton} disabled={isSubmitting}>
+                  {isSubmitting ? 'Сохраняем…' : 'Сохранить токен'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default TokenManager;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -38,11 +38,11 @@ const AdminPage = () => {
   const renderContent = () => {
     switch (activeTab) {
       case 'users':
-        return <UserManagement currentUser={currentUser} />;
+        return <UserManagement currentUser={currentUser ?? undefined} />;
       case 'catalogs':
         return <CatalogManagement />;
       default:
-        return <UserManagement currentUser={currentUser} />;
+        return <UserManagement currentUser={currentUser ?? undefined} />;
     }
   };
 

--- a/frontend/src/pages/AllegroPage.module.css
+++ b/frontend/src/pages/AllegroPage.module.css
@@ -1,0 +1,62 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.pageHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.subtitle {
+  font-size: 16px;
+  color: #64748b;
+}
+
+.tabs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tabButton {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.15);
+  color: #475569;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tabButtonActive {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.25);
+}
+
+.alert {
+  background: rgba(96, 165, 250, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  padding: 12px 16px;
+  border-radius: 10px;
+  color: #1d4ed8;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+  font-size: 18px;
+  color: #64748b;
+}

--- a/frontend/src/pages/AllegroPage.tsx
+++ b/frontend/src/pages/AllegroPage.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useMemo, useState } from 'react';
+import AllegroOverview from '../components/allegro/AllegroOverview';
+import TokenManager from '../components/allegro/TokenManager';
+import OrdersPanel from '../components/allegro/OrdersPanel';
+import OrderDetailsDrawer from '../components/allegro/OrderDetailsDrawer';
+import SyncLogsPanel from '../components/allegro/SyncLogsPanel';
+import AutomationSettings from '../components/allegro/AutomationSettings';
+import { AllegroService } from '../services/allegro';
+import {
+  AllegroAutomationSettings,
+  AllegroHealthStatus,
+  AllegroOrder,
+  AllegroOrderFilters,
+  AllegroSyncLog,
+  AllegroSyncStats,
+  AllegroToken,
+  CreateTokenPayload,
+  SyncLogsFilters,
+  UpdateTokenPayload,
+} from '../types/allegro';
+import styles from './AllegroPage.module.css';
+
+
+type AllegroTab = 'overview' | 'orders' | 'tokens' | 'logs' | 'automation';
+
+const AllegroPage = () => {
+  const [activeTab, setActiveTab] = useState<AllegroTab>('overview');
+  const [tokens, setTokens] = useState<AllegroToken[]>([]);
+  const [tokensLoading, setTokensLoading] = useState(false);
+  const [stats, setStats] = useState<AllegroSyncStats | undefined>(undefined);
+  const [health, setHealth] = useState<AllegroHealthStatus | undefined>(undefined);
+  const [syncing, setSyncing] = useState(false);
+  const [orders, setOrders] = useState<AllegroOrder[]>([]);
+  const [ordersLoading, setOrdersLoading] = useState(false);
+  const [orderFilters, setOrderFilters] = useState<AllegroOrderFilters>({ limit: 50 });
+  const [selectedOrder, setSelectedOrder] = useState<AllegroOrder | null>(null);
+  const [logs, setLogs] = useState<AllegroSyncLog[]>([]);
+  const [logsFilters, setLogsFilters] = useState<SyncLogsFilters>({ limit: 50 });
+  const [automationSettings, setAutomationSettings] = useState<AllegroAutomationSettings | undefined>();
+  const [automationLoading, setAutomationLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadTokens = async () => {
+    setTokensLoading(true);
+    try {
+      const data = await AllegroService.listTokens();
+      setTokens(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось загрузить токены Allegro.');
+    } finally {
+      setTokensLoading(false);
+    }
+  };
+
+  const loadStats = async () => {
+    try {
+      const data = await AllegroService.getSyncStats();
+      setStats(data);
+    } catch (err) {
+      console.warn('Failed to load Allegro sync stats', err);
+    }
+  };
+
+  const loadHealth = async () => {
+    try {
+      const data = await AllegroService.getHealthStatus();
+      setHealth(data);
+    } catch (err) {
+      console.warn('Failed to load Allegro health status', err);
+    }
+  };
+
+  const loadOrders = async () => {
+    setOrdersLoading(true);
+    try {
+      const data = await AllegroService.listOrders(orderFilters);
+      setOrders(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось загрузить заказы Allegro.');
+    } finally {
+      setOrdersLoading(false);
+    }
+  };
+
+  const loadLogs = async () => {
+    try {
+      const data = await AllegroService.listSyncLogs(logsFilters);
+      setLogs(data);
+    } catch (err) {
+      console.warn('Failed to load Allegro sync logs', err);
+    }
+  };
+
+  const loadAutomation = async () => {
+    setAutomationLoading(true);
+    try {
+      const data = await AllegroService.getAutomationSettings();
+      setAutomationSettings(data);
+    } catch (err) {
+      console.warn('Failed to load automation settings', err);
+    } finally {
+      setAutomationLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTokens();
+    loadStats();
+    loadHealth();
+    loadAutomation();
+  }, []);
+
+  useEffect(() => {
+    loadOrders();
+  }, [orderFilters]);
+
+  useEffect(() => {
+    loadLogs();
+  }, [logsFilters]);
+
+  const handleManualSync = async () => {
+    setSyncing(true);
+    setMessage(null);
+    try {
+      const response = await AllegroService.triggerManualSync();
+      setMessage(response.queued ? 'Синхронизация добавлена в очередь.' : 'Синхронизация запущена.');
+      await loadStats();
+      await loadOrders();
+      await loadLogs();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось запустить синхронизацию.');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleCreateToken = async (payload: CreateTokenPayload) => {
+    setTokensLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await AllegroService.createToken(payload);
+      await loadTokens();
+      await loadStats();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось создать токен Allegro.');
+      throw err;
+    } finally {
+      setTokensLoading(false);
+    }
+  };
+
+  const handleUpdateToken = async (tokenId: string, updates: UpdateTokenPayload) => {
+    setTokensLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await AllegroService.updateToken(tokenId, updates);
+      await loadTokens();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось обновить токен Allegro.');
+    } finally {
+      setTokensLoading(false);
+    }
+  };
+
+  const handleDeleteToken = async (tokenId: string) => {
+    if (!window.confirm('Удалить токен Allegro?')) return;
+    setTokensLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await AllegroService.deleteToken(tokenId);
+      await loadTokens();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось удалить токен Allegro.');
+    } finally {
+      setTokensLoading(false);
+    }
+  };
+
+  const handleRefreshToken = async (tokenId: string) => {
+    setTokensLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await AllegroService.refreshToken(tokenId);
+      await loadTokens();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось обновить токен Allegro.');
+    } finally {
+      setTokensLoading(false);
+    }
+  };
+
+  const handleToggleToken = async (tokenId: string, isActive: boolean) => {
+    setTokensLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await AllegroService.toggleTokenActive(tokenId, isActive);
+      await loadTokens();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось изменить статус токена Allegro.');
+    } finally {
+      setTokensLoading(false);
+    }
+  };
+
+  const handleSaveAutomation = async (settingsToSave: AllegroAutomationSettings) => {
+    setMessage(null);
+    setError(null);
+    try {
+      const saved = await AllegroService.updateAutomationSettings(settingsToSave);
+      setAutomationSettings(saved);
+      setMessage('Настройки автоматизации сохранены.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось сохранить настройки автоматизации.');
+      throw err;
+    }
+  };
+
+  const tabs = useMemo(
+    () => [
+      { id: 'overview' as AllegroTab, label: 'Обзор' },
+      { id: 'orders' as AllegroTab, label: 'Заказы' },
+      { id: 'tokens' as AllegroTab, label: 'Токены' },
+      { id: 'logs' as AllegroTab, label: 'Логи' },
+      { id: 'automation' as AllegroTab, label: 'Автоматизация' },
+    ],
+    [],
+  );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.pageHeader}>
+        <h1 className={styles.title}>Allegro orders backup</h1>
+        <p className={styles.subtitle}>
+          Консолидированное управление токенами, заказами и синхронизацией Allegro в единой системе склада.
+        </p>
+      </div>
+
+      <div className={styles.tabs}>
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            className={`${styles.tabButton} ${activeTab === tab.id ? styles.tabButtonActive : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {message && <div className={styles.alert}>{message}</div>}
+      {error && <div className={styles.alert} style={{ background: 'rgba(248, 113, 113, 0.12)', color: '#b91c1c', borderColor: 'rgba(248, 113, 113, 0.35)' }}>{error}</div>}
+
+      {activeTab === 'overview' && (
+        <AllegroOverview
+          tokens={tokens}
+          stats={stats}
+          health={health}
+          syncing={syncing}
+          onManualSync={handleManualSync}
+        />
+      )}
+
+      {activeTab === 'orders' && (
+        <>
+          {ordersLoading ? (
+            <div className={styles.loading}>Загрузка заказов…</div>
+          ) : (
+            <OrdersPanel
+              orders={orders}
+              loading={ordersLoading}
+              tokens={tokens}
+              filters={orderFilters}
+              onFiltersChange={setOrderFilters}
+              onRefresh={loadOrders}
+              onSelectOrder={setSelectedOrder}
+            />
+          )}
+        </>
+      )}
+
+      {activeTab === 'tokens' && (
+        <TokenManager
+          tokens={tokens}
+          loading={tokensLoading}
+          onCreate={handleCreateToken}
+          onUpdate={handleUpdateToken}
+          onDelete={handleDeleteToken}
+          onRefresh={handleRefreshToken}
+          onToggleActive={handleToggleToken}
+        />
+      )}
+
+      {activeTab === 'logs' && (
+        <SyncLogsPanel logs={logs} tokens={tokens} filters={logsFilters} onFiltersChange={setLogsFilters} />
+      )}
+
+      {activeTab === 'automation' && (
+        <>
+          {automationLoading && !automationSettings ? (
+            <div className={styles.loading}>Загрузка настроек…</div>
+          ) : (
+            <AutomationSettings initialSettings={automationSettings} onSave={handleSaveAutomation} />
+          )}
+        </>
+      )}
+
+      {selectedOrder && (
+        <OrderDetailsDrawer order={selectedOrder} onClose={() => setSelectedOrder(null)} />
+      )}
+    </div>
+  );
+};
+
+export default AllegroPage;

--- a/frontend/src/services/allegro.ts
+++ b/frontend/src/services/allegro.ts
@@ -1,0 +1,87 @@
+import {
+  createToken,
+  deleteToken,
+  fetchAutomationSettings,
+  fetchHealthStatus,
+  fetchOrder,
+  fetchOrders,
+  fetchSyncLogs,
+  fetchSyncStats,
+  fetchTokens,
+  refreshToken,
+  toggleTokenActive,
+  triggerManualSync,
+  updateAutomationSettings,
+  updateToken,
+} from '../api/allegro';
+import {
+  AllegroAutomationSettings,
+  AllegroHealthStatus,
+  AllegroOrder,
+  AllegroOrderFilters,
+  AllegroSyncLog,
+  AllegroSyncStats,
+  AllegroToken,
+  CreateTokenPayload,
+  SyncLogsFilters,
+  TriggerSyncPayload,
+  UpdateTokenPayload,
+} from '../types/allegro';
+
+export class AllegroService {
+  static async listTokens(): Promise<AllegroToken[]> {
+    return await fetchTokens();
+  }
+
+  static async createToken(payload: CreateTokenPayload): Promise<AllegroToken> {
+    return await createToken(payload);
+  }
+
+  static async updateToken(tokenId: string, payload: UpdateTokenPayload): Promise<AllegroToken> {
+    return await updateToken(tokenId, payload);
+  }
+
+  static async deleteToken(tokenId: string): Promise<void> {
+    await deleteToken(tokenId);
+  }
+
+  static async refreshToken(tokenId: string): Promise<AllegroToken> {
+    return await refreshToken(tokenId);
+  }
+
+  static async toggleTokenActive(tokenId: string, isActive: boolean): Promise<AllegroToken> {
+    return await toggleTokenActive(tokenId, isActive);
+  }
+
+  static async getSyncStats(): Promise<AllegroSyncStats> {
+    return await fetchSyncStats();
+  }
+
+  static async triggerManualSync(payload: TriggerSyncPayload = {}): Promise<{ queued: boolean; job_id?: string }> {
+    return await triggerManualSync(payload);
+  }
+
+  static async listOrders(filters: AllegroOrderFilters = {}): Promise<AllegroOrder[]> {
+    return await fetchOrders(filters);
+  }
+
+  static async getOrder(orderId: string): Promise<AllegroOrder> {
+    return await fetchOrder(orderId);
+  }
+
+  static async listSyncLogs(filters: SyncLogsFilters = {}): Promise<AllegroSyncLog[]> {
+    return await fetchSyncLogs(filters);
+  }
+
+  static async getAutomationSettings(): Promise<AllegroAutomationSettings> {
+    return await fetchAutomationSettings();
+  }
+
+  static async updateAutomationSettings(payload: AllegroAutomationSettings): Promise<AllegroAutomationSettings> {
+    return await updateAutomationSettings(payload);
+  }
+
+  static async getHealthStatus(): Promise<AllegroHealthStatus> {
+    return await fetchHealthStatus();
+  }
+}

--- a/frontend/src/types/allegro.ts
+++ b/frontend/src/types/allegro.ts
@@ -1,0 +1,135 @@
+export type AllegroTokenStatus = 'active' | 'expired' | 'revoked' | 'error' | 'pending';
+
+export interface AllegroToken {
+  token_id: string;
+  account_name: string;
+  marketplace_username?: string;
+  client_id: string;
+  scopes: string[];
+  created_at: string;
+  expires_at: string;
+  last_sync_at?: string;
+  status: AllegroTokenStatus;
+  is_default: boolean;
+  orders_imported: number;
+  last_error?: string | null;
+}
+
+export interface AllegroSyncStats {
+  total_tokens: number;
+  active_tokens: number;
+  orders_synced_today: number;
+  orders_pending: number;
+  last_sync_at?: string;
+  backlog_orders: number;
+  failed_syncs_today: number;
+}
+
+export interface AllegroBuyer {
+  name: string;
+  email?: string;
+  phone?: string;
+}
+
+export interface AllegroOrderItem {
+  line_item_id: string;
+  sku: string;
+  name: string;
+  quantity: number;
+  unit_price: number;
+  currency: string;
+  vat_rate?: number;
+  fulfillment_status?: string;
+}
+
+export type AllegroOrderStatus =
+  | 'new'
+  | 'processing'
+  | 'ready_for_shipment'
+  | 'shipped'
+  | 'cancelled'
+  | 'returned';
+
+export interface AllegroOrder {
+  order_id: string;
+  token_id: string;
+  marketplace_order_id: string;
+  status: AllegroOrderStatus;
+  payment_status: 'paid' | 'pending' | 'refunded' | 'failed';
+  fulfillment_status: 'pending' | 'in_progress' | 'fulfilled' | 'cancelled';
+  buyer: AllegroBuyer;
+  total_amount: number;
+  currency: string;
+  created_at: string;
+  updated_at: string;
+  last_synced_at?: string;
+  delivery_method?: string;
+  shipping_tracking_number?: string;
+  items: AllegroOrderItem[];
+  tags?: string[];
+  notes?: string;
+}
+
+export interface AllegroOrderFilters {
+  token_id?: string;
+  status?: AllegroOrderStatus | 'all';
+  payment_status?: AllegroOrder['payment_status'] | 'all';
+  fulfillment_status?: AllegroOrder['fulfillment_status'] | 'all';
+  created_from?: string;
+  created_to?: string;
+  search?: string;
+  limit?: number;
+}
+
+export interface AllegroSyncLog {
+  log_id: string;
+  token_id?: string;
+  token_account_name?: string;
+  event_type: 'orders_sync' | 'token_refresh' | 'webhook' | 'maintenance';
+  status: 'success' | 'warning' | 'error' | 'info';
+  message: string;
+  created_at: string;
+  duration_ms?: number;
+  details?: Record<string, unknown>;
+}
+
+export interface AllegroAutomationSettings {
+  auto_sync_enabled: boolean;
+  sync_interval_minutes: number;
+  order_states_to_import: AllegroOrderStatus[];
+  notify_on_failures: boolean;
+  notify_emails: string[];
+}
+
+export interface AllegroHealthStatus {
+  overall_status: 'ok' | 'degraded' | 'down';
+  services: Array<{
+    service: string;
+    status: 'ok' | 'degraded' | 'down';
+    last_check_at: string;
+    message?: string;
+  }>;
+}
+
+export interface TriggerSyncPayload {
+  token_id?: string;
+  since?: string;
+}
+
+export interface CreateTokenPayload {
+  authorization_code: string;
+  account_name: string;
+  is_default?: boolean;
+}
+
+export interface UpdateTokenPayload {
+  account_name?: string;
+  is_default?: boolean;
+}
+
+export interface SyncLogsFilters {
+  token_id?: string;
+  status?: AllegroSyncLog['status'] | 'all';
+  event_type?: AllegroSyncLog['event_type'] | 'all';
+  limit?: number;
+}


### PR DESCRIPTION
## Summary
- add a dedicated Allegro orders backup area with overview, order list, token management, logs, and automation tabs
- implement reusable Allegro UI components, API client, service layer, and shared types, plus navigation entry points
- pull in date-fns for timeline formatting and adjust existing admin panel typing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da802867c083308e372667838a6c29